### PR TITLE
Remove spa mode by default

### DIFF
--- a/src/Filament/Panels/KnowledgeBasePanel.php
+++ b/src/Filament/Panels/KnowledgeBasePanel.php
@@ -226,7 +226,6 @@ class KnowledgeBasePanel extends Panel
 
             // TODO: Replace with ->navigationItems and ->navigationGroups to support custom pages
             ->navigation($this->makeNavigation(...))
-            ->spa()
         ;
     }
 


### PR DESCRIPTION
Currently the panel is configured to always be in spa mode, with no ability for the developer to override that.

Now you can set spa mode when you configure other stuff in the panel like so:

```php
KnowledgeBasePanel::configureUsing(
            fn (KnowledgeBasePanel $panel) => $panel->spa()
);
```

Technically this is a "breaking" change as anyone who updates will have spa mode turned off until they manually enable it.