### PR TITLE
Safely get view content

### DIFF
--- a/src/Actions/Forms/Components/HelpAction.php
+++ b/src/Actions/Forms/Components/HelpAction.php
@@ -21,11 +21,15 @@ class HelpAction extends Action
             $articleClass => ! empty($articleClass),
         ]);
 
-        return new HtmlString(\Blade::render(<<<blade
+         $replacementStringId = \Str::random();
+
+        $parsed = \Blade::render(<<<blade
 <x-filament-knowledge-base::content class="$classes">
-$html
+$replacementStringId
 </x-filament-knowledge-base::content>
-blade));
+blade);
+
+        return new HtmlString( \Str::replace($replacementStringId, $html, $parsed));
     }
 
     public static function forDocumentable(Documentable | string $documentable): static


### PR DESCRIPTION
Fixes #31

This fix is partly inspired by Aaron Francis' post on a [different but similar security issue](https://aaronfrancis.com/2023/rendering-blade-components-in-markdown-e2e74e55).