### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,8 +298,8 @@ want to integrate. You can either return the `IDs` as strings (dot-separated pat
 helper to retrieve the model:
 
 ```php
-use use Guava\FilamentKnowledgeBase\Contracts\HasKnowledgeBase;
-
+use Guava\FilamentKnowledgeBase\Contracts\HasKnowledgeBase;
+use Guava\FilamentKnowledgeBase\Facades\KnowledgeBase;
 class UserResource extends Resource implements HasKnowledgeBase
 {
     // ...
@@ -310,7 +310,7 @@ class UserResource extends Resource implements HasKnowledgeBase
         return [
             'users.introduction',
             'users.authentication',
-            FilamentKnowledgeBase::model()::find('users.permissions'),
+            KnowledgeBase::model()::find('users.permissions'),
         ];
     }
 }


### PR DESCRIPTION
Fixed typo in the class import.

Added the missing a class import which is required for accessing the KnowledgeBase model shown in the example.