### PR TITLE
Fix breadcrumbs when using sub-pages on top-level documents

### DIFF
--- a/src/Models/FlatfileDocumentation.php
+++ b/src/Models/FlatfileDocumentation.php
@@ -183,6 +183,8 @@ class FlatfileDocumentation extends Model implements Documentable
         $parts = str($this->getId())->explode('.', 3);
         if (count($parts) >= 3) {
             return $parts[0] . '.' . $parts[1];
+        } elseif (count($parts) == 2) {
+            return $parts[0];
         }
 
         return null;


### PR DESCRIPTION
This setup would throw an error when accessing the sub-page.

File structure
```
- top.md
- top
  - sub.md
 ```
_sub.md_
```markdown
---
parent: Top
---
Sub page content
```