### PR TITLE
Supporting group title, icon and order

### DIFF
--- a/src/Filament/Navigation/NavigationSortableGroup.php
+++ b/src/Filament/Navigation/NavigationSortableGroup.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Guava\FilamentKnowledgeBase\Filament\Navigation;
+
+use Closure;
+use Filament\Navigation\NavigationGroup;
+
+class NavigationSortableGroup extends NavigationGroup
+{
+    protected int|Closure|null $sort = 999999;
+
+    public function sort(int|Closure|null $sort): static
+    {
+        $this->sort = $sort;
+
+        return $this;
+    }
+
+    public function getSort(): int
+    {
+        return $this->evaluate($this->sort) ?? -1;
+    }
+}

--- a/src/Filament/Panels/KnowledgeBasePanel.php
+++ b/src/Filament/Panels/KnowledgeBasePanel.php
@@ -294,7 +294,7 @@ class KnowledgeBasePanel extends Panel
 
         $documentables
             ->filter(fn (Documentable $documentable) => $documentable->isRegistered())
-            ->filter(fn (Documentable $documentable) => ! str_ends_with($documentable->getId(), '._group'))
+            ->filter(fn (Documentable $documentable) => $documentable->getId() !== '_group')
             ->filter(fn (Documentable $documentable) => $documentable->getParent() === null)
             ->groupBy(fn (Documentable $documentable) => $documentable->getGroup())
             ->map(

--- a/src/Markdown/MarkdownRenderer.php
+++ b/src/Markdown/MarkdownRenderer.php
@@ -73,6 +73,7 @@ class MarkdownRenderer
             ],
             'heading_permalink' => [
                 'id_prefix' => '',
+                'fragment_prefix' => '',
                 'symbol' => $anchorSymbol ?? '',
                 'html_class' => Arr::toCssClasses([
                     'gu-kb-anchor md:absolute md:-left-8 mr-2 md:mr-0 text-primary-600 dark:text-primary-500 font-bold',

--- a/src/Models/FlatfileDocumentation.php
+++ b/src/Models/FlatfileDocumentation.php
@@ -202,7 +202,7 @@ class FlatfileDocumentation extends Model implements Documentable
 
     public function getIcon(): ?string
     {
-        return $this->icon ?? 'heroicon-o-document';
+        return $this->icon;
     }
 
     public function isRegistered(): bool


### PR DESCRIPTION
 This will probably need several iterations to get right, but here's what I've got working.

```
docs
└── en
    ├── changelog.md
    ├── _group.md
    ├── tld
    │   ├── _group.md
    │   └── something.md
    ├── tld.md
    └── users
        ├── administration
        │   └── hello.md
        ├── administration.md
        └── _group.md
```

![image](https://github.com/user-attachments/assets/154be993-4898-43eb-bd80-31f212c77b51)
![image](https://github.com/user-attachments/assets/b780a6db-dd90-499d-8128-d07c3f39d19f)

## Features
- `_group.md` supports _title:_, _icon:_ and _order:_
- No `_group.md` will show, regardless if used
- Tree depth dependent on what Filament supports
- Groups and items can be intermixed
    -  Items next to each other will still be grouped together, the same way that FilamentPHP does it now, to reduce spacing

## Depth options
**Note:** FilamentPHP only allows icons at one level

1] Document with icon

2] Document with icon and sub-documents using _parent:_
  - If sub-documents have icons, they will be ignored

3] Group with icon and sub-documents
  - Next depth will be ignored

4] Group without icon and documents with icons
  - Sub-documents with _parent:_, icons will be ignored