### PR TITLE
Fix list styling in modals

### DIFF
--- a/resources/views/components/content.blade.php
+++ b/resources/views/components/content.blade.php
@@ -1,7 +1,9 @@
+@use(Guava\FilamentKnowledgeBase\Facades\KnowledgeBase)
 <article
     {{ $attributes->class([
-    'gu-kb-article',
-]) }}
+        'gu-kb-article',
+        '[&_ul]:list-[revert] [&_ol]:list-[revert] [&_ul]:ml-4 [&_ol]:ml-4' => ! KnowledgeBase::panel()->shouldDisableDefaultClasses(),
+    ]) }}
     x-ignore
     ax-load
     ax-load-src="{{ \Filament\Support\Facades\FilamentAsset::getAlpineComponentSrc('anchors-component', 'guava/filament-knowledge-base') }}"

--- a/resources/views/documentation.blade.php
+++ b/resources/views/documentation.blade.php
@@ -29,7 +29,6 @@
 >
     <x-filament-knowledge-base::content @class([
         "gu-kb-article-full",
-        "[&_ul]:list-[revert] [&_ol]:list-[revert] [&_ul]:ml-4 [&_ol]:ml-4",
         $articleClass => ! empty($articleClass),
     ])>
         {!!  $this->record->getHtml() !!}


### PR DESCRIPTION
- Move list styling from the full article template to the content template.
- Add checking for default classes being disabled to match the MarkdownRenderer.

Fixes #80