### PR TITLE
Fix: Support dynamic locale switching (Fixes #85)

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,15 @@ Below is a list of currently available options in the front matter.
 
 
 
+#### Order
+Allows you to define the sort order of the documentation page. Lower numbers appear first.
+
+```md
+---
+order: 1
+---
+```
+
 #### Group
 Allows you to define the group (and it's title) of the documentation page.
 
@@ -383,6 +392,14 @@ parent: my-parent
 ```
 
 So for a file in `docs/en/prologue/getting-started/intro.md`, the parent would be `getting-started`.
+
+You can also use the **ID** of another documentation page to nest it under that page, regardless of directory structure. The ID is the path relative to the locale directory, separated by dots (e.g. `fleet.intro` for `fleet/intro.md`).
+
+```md
+---
+parent: fleet.intro
+---
+```
 
 
 


### PR DESCRIPTION
# Fix: Support dynamic locale switching (Fixes #85)

## Description
This PR fixes an issue where documentation content and the sidebar would stick to the boot-time locale (typically from `.env`), ignoring runtime locale changes (e.g., via middleware).

## Changes
1.  **Multi-Locale Loading**: Updated `FlatfileNode::getRows()` to scan and load documentation for **all** available locales found in the docs directory, rather than just the current app locale.
    *   Records are now namespaced by locale (e.g., `de.welcome`) to prevent ID collisions in the Sushi cache.
    *   Added a [locale](cci:1://file://wsl.localhost/Ubuntu/home/robo/projects/beegoodit/timesloth-beegoodit-de/app/Filament/Widgets/TimeEntriesCalendar.php:44:4-50:5) column to the [FlatfileNode](cci:2://file://wsl.localhost/Ubuntu/home/robo/projects/composer/filament-knowledge-base/src/Models/FlatfileNode.php:23:0-310:1) schema.
2.  **Strict Filtering**: Added a **Global Scope** to [FlatfileNode](cci:2://file://wsl.localhost/Ubuntu/home/robo/projects/composer/filament-knowledge-base/src/Models/FlatfileNode.php:23:0-310:1) that filters all queries by `App::getLocale()`.
    *   This ensures that `FlatfileNode::all()`, used by the sidebar navigation builder, only returns items for the current user's language.
    *   This prevents "sidebar leakage" where English items would appear for German users if navigation was built before the locale switch.
3.  **Route Binding**: Updated [resolveRouteBindingQuery](cci:1://file://wsl.localhost/Ubuntu/home/robo/projects/composer/filament-knowledge-base/src/Models/FlatfileNode.php:287:4-293:5) to scope lookups to the current locale.

## Verification
Verified that switching the user's locale at runtime correctly updates both the documentation content and the sidebar navigation structure.