### PR TITLE
Use ->dropdownTeleport() for HelpMenu

### DIFF
--- a/src/Livewire/HelpMenu.php
+++ b/src/Livewire/HelpMenu.php
@@ -85,6 +85,7 @@ class HelpMenu extends Component implements HasActions, HasForms
             ->iconSize('lg')
             ->color('gray')
             ->button()
+            ->dropdownTeleport()
         ;
     }
 


### PR DESCRIPTION
Hey,

apparently there is an issue with the positioning of the Help Menu. This was reported to my Environment Indicator plugin: https://github.com/pxlrbt/filament-environment-indicator/issues/32#issuecomment-3916839393

Since Filament's user menu dropdown positioned as expected, I compared those two and realised that the user menu had "teleport" added. This should fix the positioning issue.

