### PR TITLE
Add Laravel 13 / Symfony 8 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,13 @@
         "php": "^8.2",
         "calebporzio/sushi": "^2.5",
         "filament/filament": "^5.0",
-        "illuminate/contracts": "^11.0|^12.0",
+        "illuminate/contracts": "^11.0|^12.0|^13.0",
         "league/commonmark": "^2.4",
         "n0sz/commonmark-marker-extension": "^1.0",
         "phiki/phiki": "^2.0",
         "spatie/laravel-package-tools": "^1.14.0",
         "spatie/php-structure-discoverer": "^2.1",
-        "symfony/yaml": "^7.0"
+        "symfony/yaml": "^7.0|^8.0"
     },
     "require-dev": {
         "larastan/larastan": "^3.0",


### PR DESCRIPTION
## Summary
- Widen `illuminate/contracts` to `^11.0|^12.0|^13.0`
- Widen `symfony/yaml` to `^7.0|^8.0`

Allows installation on Laravel 13 / Symfony 8 without other changes.

Refs #106 

## Test plan
- [ ] `composer install` on Laravel 13 app
- [ ] Package discovery + knowledge base panel render